### PR TITLE
Finally done the RP warning system!

### DIFF
--- a/config.json
+++ b/config.json
@@ -94,6 +94,8 @@
         "pointsDeletionTime": 10E3,
         "warnThresholds": [450, 500, 550],
         "leaderboardChannel": "1175234775414472775",
+        "warnMessageCooldown": 30,
+        "warnMessageDeletionTime": 5,
         "channels": [
             "496962434917990410",
             "496957983973179392"


### PR DESCRIPTION
So I managed warning messages for users reaching level warnings 1, 2 and 3. There is also a timeout of 30 minutes (you can change) to avoid sending a warning of same level (in case points go up and down) Message warnings stay up to 5 minutes, but are deleted sooner to be replaced in case a higher level is reached beforehand. After level warning reached 3, all RP messages are deleted until the warning level returns to 2. I also made sure they don't give any point during the moment.

Let me know if there is anything to fix and change!